### PR TITLE
Fix a wrong closing tag

### DIFF
--- a/resources/demos/radio/grouped-inline.md
+++ b/resources/demos/radio/grouped-inline.md
@@ -30,5 +30,5 @@
     >
         Inline Option 5
     </x-radio>
-</x-radio-group>
+</x-checkbox-group>
 ```


### PR DESCRIPTION
Fixes the wrong </x-checkbox-group> closing tag. Was <x-radio-group> instead, which does not exist - at the moment. :)